### PR TITLE
Add notifier function, OnFocusLost

### DIFF
--- a/src/main/java/industries/laser/mannequin/Mannequin.kt
+++ b/src/main/java/industries/laser/mannequin/Mannequin.kt
@@ -24,8 +24,25 @@ class Mannequin {
     private fun listenToEditText(validated: MannequinValidated<String>) {
         val editText = validated.view as EditText
         when (validated.event) {
-            ValidationEvent.OnKey -> editText.doAfterTextChanged {
-                validated.validator(it.toString())
+            ValidationEvent.OnKey -> editText.doAfterTextChanged { editable ->
+                validated.validator?.let { validator ->
+                    val valid = validator(editable.toString())
+                    if (validated.isValid != valid) {
+                        validated.isValid = valid
+                        validated.notifier?.invoke(editText, valid)
+                    }
+                }
+            }
+            ValidationEvent.OnFocusLost -> editText.setOnFocusChangeListener { view, focused ->
+                if (!focused) {
+                    validated.validator?.let { validator ->
+                        val valid = validator(editText.text.toString())
+                        if (validated.isValid != valid) {
+                            validated.isValid = valid
+                            validated.notifier?.invoke(editText, valid)
+                        }
+                    }
+                }
             }
         }
     }

--- a/src/main/java/industries/laser/mannequin/MannequinValidated.kt
+++ b/src/main/java/industries/laser/mannequin/MannequinValidated.kt
@@ -5,7 +5,9 @@ import industries.laser.mannequin.validators.Validator
 
 class MannequinValidated<T>(val view: View) {
     var event: ValidationEvent? = null
-    lateinit var validator: Validator<T>
+    var validator: Validator<T>? = null
+    var notifier: ((View, Boolean) -> Unit)? = null
+    var isValid: Boolean = true
 
     infix fun during(validationEvent: ValidationEvent): MannequinValidated<T> {
         this.event = validationEvent
@@ -14,6 +16,11 @@ class MannequinValidated<T>(val view: View) {
 
     infix fun via(function: T.() -> Boolean): MannequinValidated<T> {
         this.validator = function
+        return this
+    }
+
+    infix fun notifies(function: (View, Boolean) -> Unit): MannequinValidated<T> {
+        this.notifier = function
         return this
     }
 }


### PR DESCRIPTION
Allows outside classes to receive the validation events, rather than managing that state internally